### PR TITLE
failing when responding with callback grater than 55 in tests to reproduce real limitation

### DIFF
--- a/tests/TelegramBotTestUser.js
+++ b/tests/TelegramBotTestUser.js
@@ -43,8 +43,7 @@ module.exports = async function({client, greaterFunction, selectFunction}){
                 }else if(response.text.includes("?")){
                     let options = response.reply_markup.inline_keyboard
                     let selectedOption = await selectOption(options[0][0], options[1][0])
-                    const callback = client.makeCallbackQuery(selectedOption.callback_data);
-                    await client.sendCallback(callback);
+                    await sendCallBack(selectedOption.callback_data)
                 }
             }
         },
@@ -70,16 +69,15 @@ module.exports = async function({client, greaterFunction, selectFunction}){
                     let selectedOption
                     if(await selectFunction(response.text)) selectedOption = options[0][0]
                     else selectedOption = options[0][1]
-                    const callback = client.makeCallbackQuery(selectedOption.callback_data);
-                    await client.sendCallback(callback);
+                    await sendCallBack(selectedOption.callback_data)
                 }
             }
         },
         addRecurrentTask: async function(name){
             await sendMessage("/recurrent")
-            await waitResponse()
+            await waitResponses()
             await sendMessage(name)
-            await waitResponse()
+            await waitResponses()
         },
         getRecurrentTasks: async function(){
             await sendMessage("/recurrent")
@@ -98,8 +96,7 @@ module.exports = async function({client, greaterFunction, selectFunction}){
                     complete: async function(){
                         //console.log('reply_markup', response.message.reply_markup)
                         let completeOption = response.message.reply_markup.inline_keyboard[0][0]
-                        const callback = client.makeCallbackQuery(completeOption.callback_data);
-                        await client.sendCallback(callback);
+                        await sendCallBack(completeOption.callback_data)
                     }
                 })
             }
@@ -117,5 +114,11 @@ module.exports = async function({client, greaterFunction, selectFunction}){
             //get all the recurrent tasks with their possible callbacks
             //call the callback for the one with the given name
         }
+    }
+
+    async function sendCallBack(data){
+        if (data.length > 55) throw new Error(`Trying to send a callback lenght greater than 55 allowed by current telegram API: ${data}`)
+        const callback = client.makeCallbackQuery(data);
+        await client.sendCallback(callback);
     }
 }

--- a/tests/priorityTests.js
+++ b/tests/priorityTests.js
@@ -120,7 +120,26 @@ module.exports = function(){
                 // expect(await tasks[0].get('time since last completion')).to.equal('2 segundos')
             })
 
-            it('add several recurrent tasks')
+            it('add several recurrent tasks', async function(){
+                this.timeout(10000)
+                await user.addRecurrentTask('heater maintenance')
+                await user.addRecurrentTask('review ceil painting looking for defects')
+                await user.addRecurrentTask('clean outside walls')
+                let tasks = await user.getRecurrentTasks();
+                expect(tasks.length).to.equal(3)
+                expect(await tasks[0].get('name')).to.equal('heater maintenance')
+                expect(await tasks[1].get('name')).to.equal('review ceil painting looking for defects')
+                expect(await tasks[2].get('name')).to.equal('clean outside walls')
+            })
+
+            it('allow very long recurrent task names', async function(){
+                this.timeout(5000)
+                await user.addRecurrentTask('review ceil painting looking for defects in all the corners without any exception bla bla bla bla bla bla bla bla')
+                let tasks = await user.getRecurrentTasks();
+                expect(tasks.length).to.equal(1)
+                expect(await tasks[0].get('name')).to.equal('review ceil painting looking for defects in all the corners without any exception bla bla bla bla bla bla bla bla')
+            })
+
             it('show greater time first')
             it('allow completion of recurrent tasks', async function(){
                 this.timeout(5000)


### PR DESCRIPTION
refactored sending callback method
allow long task names
tested several recurrent tasks